### PR TITLE
Fix wrong documentation url

### DIFF
--- a/server/scripts/vulsrepo.service
+++ b/server/scripts/vulsrepo.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=vulsrepo daemon
-Documentation=https://github.com/ishiDACo/vulsrepo
+Documentation=https://vuls.io/docs/en/vulsrepo.html
 
 [Service]
 ExecStart = /home/vuls-user/vulsrepo/server/vulsrepo-server

--- a/server/scripts/vulsrepo.service
+++ b/server/scripts/vulsrepo.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=vulsrepo daemon
-Documentation=https://github.com/usiusi360/vulsrepo
+Documentation=https://github.com/ishiDACo/vulsrepo
 
 [Service]
 ExecStart = /home/vuls-user/vulsrepo/server/vulsrepo-server


### PR DESCRIPTION
The current documentation url is still the one from the previous repo.